### PR TITLE
fix: Store all dates in a timezone aware format

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,3 +3,4 @@ pip-tools
 requests
 pymongo
 dnspython
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ idna==2.10                # via requests
 pathspec==0.8.0           # via black
 pip-tools==5.2.1          # via -r requirements.in
 pymongo==3.10.1           # via -r requirements.in
+pytz==2020.1              # via -r requirements.in
 regex==2020.6.8           # via black
 requests==2.24.0          # via -r requirements.in
 six==1.15.0               # via pip-tools

--- a/src/worker.py
+++ b/src/worker.py
@@ -1,5 +1,4 @@
 import datetime
-import dateutil.parser as dparser
 import os
 
 import github
@@ -35,11 +34,6 @@ class Worker:
         self.database_instance.upsert_repository(repository)
 
     def should_fetch_images(self, last_commit_at, last_import_at, is_repository_new):
-        last_commit_at = (
-            dparser.parse(last_commit_at, fuzzy=True)
-            if last_commit_at is not None
-            else None
-        )
         images_will_be_fetched = (
             is_repository_new
             or last_import_at is None


### PR DESCRIPTION
[Related colorschemes.dev issue](https://github.com/reobin/colorschemes.dev/issues/58)

Storing all dates in a timezone aware UTC format makes it easier for the app to deal with the dates.